### PR TITLE
[FEAT/#48] Splash Activity 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt)
-    id("androidx.navigation.safeargs.kotlin")
 }
 
 val properties = Properties()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt)
+    id("androidx.navigation.safeargs.kotlin")
 }
 
 val properties = Properties()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,16 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.jetbrainsKotlinJvm) apply false
     alias(libs.plugins.dagger.hilt) apply false
+    alias(libs.plugins.navigationSafeArgs) apply false
 }
 
 apply(from = file(path = "gradle/projectDependencyGraph.gradle"))
-
-buildscript {
-    repositories {
-        google()
-    }
-    dependencies {
-        val nav_version = "2.7.7"
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version")
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,3 +11,13 @@ plugins {
 }
 
 apply(from = file(path = "gradle/projectDependencyGraph.gradle"))
+
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        val nav_version = "2.7.7"
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version")
+    }
+}

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.dagger.hilt)
+    alias(libs.plugins.navigationSafeArgs)
 }
 
 android {

--- a/feature/src/main/AndroidManifest.xml
+++ b/feature/src/main/AndroidManifest.xml
@@ -9,9 +9,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Kkumul">
         <activity
-            android:name=".auth.LoginActivity"
+            android:name=".splash.SplashActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -20,20 +19,29 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".auth.LoginActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".signup.SetNameActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait" />
         <activity
             android:name=".signup.SetProfileActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait" />
         <activity
             android:name=".signup.WelcomeActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait" />
         <activity
             android:name=".MainActivity"
             android:exported="false"
+            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait" />
     </application>
 

--- a/feature/src/main/java/com/teamkkumul/feature/MainActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.teamkkumul.feature
 
+import android.content.Context
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
@@ -13,6 +15,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun initView() {
         setupBottomNavigation()
+        binding.clMain.setOnClickListener {
+            hideKeyBoard()
+        }
     }
 
     private fun setupBottomNavigation() {
@@ -40,6 +45,14 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             } else {
                 statusBarColorOf(R.color.white0)
             }
+        }
+    }
+
+    private fun hideKeyBoard() {
+        val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val currentFocus = currentFocus
+        if (currentFocus != null) {
+            inputMethodManager.hideSoftInputFromWindow(currentFocus.windowToken, 0)
         }
     }
 }

--- a/feature/src/main/java/com/teamkkumul/feature/signup/SetNameActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/signup/SetNameActivity.kt
@@ -1,8 +1,10 @@
 package com.teamkkumul.feature.signup
 
+import android.content.Context
 import android.content.Intent
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import androidx.core.widget.doAfterTextChanged
 import com.teamkkumul.core.ui.base.BindingActivity
 import com.teamkkumul.core.ui.util.context.colorOf
@@ -22,6 +24,9 @@ class SetNameActivity : BindingActivity<ActivitySetNameBinding>(R.layout.activit
         binding.btnNext.setOnClickListener {
             val inputName = binding.etSetName.text.toString()
             navigateToSetProfile(inputName)
+        }
+        binding.clSetName.setOnClickListener {
+            hideKeyBoard()
         }
     }
 
@@ -77,6 +82,14 @@ class SetNameActivity : BindingActivity<ActivitySetNameBinding>(R.layout.activit
             putExtra(INPUT_NAME, inputName)
         }
         startActivity(intent)
+    }
+
+    private fun hideKeyBoard() {
+        val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val currentFocus = currentFocus
+        if (currentFocus != null) {
+            inputMethodManager.hideSoftInputFromWindow(currentFocus.windowToken, 0)
+        }
     }
 
     companion object {

--- a/feature/src/main/java/com/teamkkumul/feature/signup/SetNameActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/signup/SetNameActivity.kt
@@ -1,13 +1,12 @@
 package com.teamkkumul.feature.signup
 
-import android.content.Context
 import android.content.Intent
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import androidx.core.widget.doAfterTextChanged
 import com.teamkkumul.core.ui.base.BindingActivity
 import com.teamkkumul.core.ui.util.context.colorOf
+import com.teamkkumul.core.ui.util.context.hideKeyboard
 import com.teamkkumul.feature.R
 import com.teamkkumul.feature.databinding.ActivitySetNameBinding
 import com.teamkkumul.feature.utils.Debouncer
@@ -26,7 +25,7 @@ class SetNameActivity : BindingActivity<ActivitySetNameBinding>(R.layout.activit
             navigateToSetProfile(inputName)
         }
         binding.clSetName.setOnClickListener {
-            hideKeyBoard()
+            hideKeyboard(binding.clSetName)
         }
     }
 
@@ -82,14 +81,6 @@ class SetNameActivity : BindingActivity<ActivitySetNameBinding>(R.layout.activit
             putExtra(INPUT_NAME, inputName)
         }
         startActivity(intent)
-    }
-
-    private fun hideKeyBoard() {
-        val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        val currentFocus = currentFocus
-        if (currentFocus != null) {
-            inputMethodManager.hideSoftInputFromWindow(currentFocus.windowToken, 0)
-        }
     }
 
     companion object {

--- a/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
@@ -2,35 +2,32 @@ package com.teamkkumul.feature.splash
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.os.Bundle
+import androidx.lifecycle.lifecycleScope
 import com.teamkkumul.core.ui.base.BindingActivity
 import com.teamkkumul.core.ui.util.context.statusBarColorOf
 import com.teamkkumul.feature.R
 import com.teamkkumul.feature.auth.LoginActivity
 import com.teamkkumul.feature.databinding.ActivitySplashBinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @SuppressLint("CustomSplashScreen")
 class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
 
-    private val activityScope = CoroutineScope(Dispatchers.Main)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initView()
+    }
 
     override fun initView() {
         statusBarColorOf(R.color.main_color)
-        activityScope.launch {
+        lifecycleScope.launch {
             delay(1000)
 
             val intent = Intent(this@SplashActivity, LoginActivity::class.java)
             startActivity(intent)
             finish()
         }
-    }
-
-    override fun onPause() {
-        activityScope.cancel()
-        super.onPause()
     }
 }

--- a/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
@@ -21,7 +21,7 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     override fun initView() {
         statusBarColorOf(R.color.main_color)
         activityScope.launch {
-            delay(300)
+            delay(1000)
 
             val intent = Intent(this@SplashActivity, LoginActivity::class.java)
             startActivity(intent)

--- a/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/splash/SplashActivity.kt
@@ -1,0 +1,36 @@
+package com.teamkkumul.feature.splash
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import com.teamkkumul.core.ui.base.BindingActivity
+import com.teamkkumul.core.ui.util.context.statusBarColorOf
+import com.teamkkumul.feature.R
+import com.teamkkumul.feature.auth.LoginActivity
+import com.teamkkumul.feature.databinding.ActivitySplashBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@SuppressLint("CustomSplashScreen")
+class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
+
+    private val activityScope = CoroutineScope(Dispatchers.Main)
+
+    override fun initView() {
+        statusBarColorOf(R.color.main_color)
+        activityScope.launch {
+            delay(300)
+
+            val intent = Intent(this@SplashActivity, LoginActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+    }
+
+    override fun onPause() {
+        activityScope.cancel()
+        super.onPause()
+    }
+}

--- a/feature/src/main/res/drawable/ic_splash_kkumul.xml
+++ b/feature/src/main/res/drawable/ic_splash_kkumul.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="159dp"
+    android:height="154dp"
+    android:viewportWidth="159"
+    android:viewportHeight="154">
+  <path
+      android:pathData="M20,97.46a59.5,36.18 0,1 0,119 0a59.5,36.18 0,1 0,-119 0z"
+      android:strokeAlpha="0.12"
+      android:fillColor="#00A775"
+      android:fillAlpha="0.12"/>
+  <path
+      android:pathData="M135.7,71.75C134.04,67.02 131.16,62.44 127.51,59.23C122.54,54.84 116.68,49.31 116.68,42.69V41.44C116.68,18.75 97.88,0.36 74.69,0.36H68.11C46.1,0.36 28.25,17.82 28.25,39.36V57.72C28.25,61.52 27.73,65.28 26.73,68.94C23.63,74.09 21.9,79.78 21.9,85.75C21.9,109.09 48.11,128.01 80.45,128.01C112.79,128.01 139,109.09 139,85.75C139,80.85 137.83,76.14 135.7,71.75Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M50.91,56.27C52.37,56.27 53.55,54.85 53.55,53.11C53.55,51.36 52.38,49.94 50.91,49.94C49.45,49.94 48.28,51.36 48.28,53.11C48.28,54.85 49.45,56.27 50.91,56.27Z"
+      android:fillColor="#0D0B0A"/>
+  <path
+      android:pathData="M62.52,59.44C63.97,59.44 65.15,58.02 65.15,56.27C65.15,54.53 63.98,53.11 62.52,53.11C61.06,53.11 59.88,54.53 59.88,56.27C59.88,58.02 61.06,59.44 62.52,59.44Z"
+      android:fillColor="#0D0B0A"/>
+  <path
+      android:pathData="M38.54,56.16a3.16,4.75 105,1 0,9.17 2.46a3.16,4.75 105,1 0,-9.17 -2.46z"
+      android:fillColor="#FFB894"/>
+  <path
+      android:pathData="M63.85,62.49a3.16,4.75 105,1 0,9.17 2.46a3.16,4.75 105,1 0,-9.17 -2.46z"
+      android:fillColor="#FFB894"/>
+</vector>

--- a/feature/src/main/res/layout/activity_main.xml
+++ b/feature/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_main"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/feature/src/main/res/layout/activity_splash.xml
+++ b/feature/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/main_color">
+
+    <ImageView
+        android:id="@+id/iv_splash_kkumul"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_splash_kkumul"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/src/main/res/layout/activity_splash.xml
+++ b/feature/src/main/res/layout/activity_splash.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@color/main_color">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ImageView
-        android:id="@+id/iv_splash_kkumul"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_splash_kkumul"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+    <data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/main_color">
+
+        <ImageView
+            android:id="@+id/iv_splash_kkumul"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_splash_kkumul"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/feature/src/main/res/values/themes.xml
+++ b/feature/src/main/res/values/themes.xml
@@ -13,7 +13,9 @@
         <!--        <item name="snackbarStyle">@style/CustomSnackBar</item>-->
     </style>
 
-    <style name="Theme.Kkumul" parent="Base.Theme.Kkumul" />
+    <style name="Theme.Kkumul" parent="Base.Theme.Kkumul">
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
 
     <style name="ShapeAppearanceOverlay.App.CornerSize50Percent" parent="">
         <item name="cornerSize">50%</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,6 +116,7 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspplugin" }
+navigationSafeArgs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "jetpack-navi" }
 
 [bundles]
 retrofit = ["retrofit", "retrofit-kotlin-serialization-converter"]


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #48

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] Splash Activity 화면 구현
- [x] SetNameActivity, MainActivity에서 빈 화면 클릭 시 키보드 내려가기 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/user-attachments/assets/d369b20e-eff2-47e2-bab6-12f827acc930


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
스플래시 화면의 시간은 1초로 구현했습니다 !