### PR TITLE
[Fix/#108] error handling 로직 수정, reissue 에러 수정

### DIFF
--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.teamkkumul.core.data.mapper.toReadyStatusModel
 import com.teamkkumul.core.data.mapper.toTodayMeetingModel
 import com.teamkkumul.core.data.mapper.toUserModel
 import com.teamkkumul.core.data.repository.HomeRepository
-import com.teamkkumul.core.data.utils.toApiResult
+import com.teamkkumul.core.data.utils.handleThrowable
 import com.teamkkumul.core.network.api.HomeService
 import com.teamkkumul.core.network.dto.request.RequestReadyInfoInputDto
 import com.teamkkumul.model.home.HomeMembersStatus
@@ -23,13 +23,13 @@ internal class HomeRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun getTodayMeeting(): Result<HomeTodayMeetingModel?> = runCatching {
         homeService.getTodayMeeting().data?.toTodayMeetingModel()
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun getUpComingMeeting(): Result<List<HomeTodayMeetingModel>> = runCatching {
@@ -37,14 +37,14 @@ internal class HomeRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun getReadyStatus(promiseId: Int): Result<HomeReadyStatusModel?> =
         runCatching {
             homeService.getReadyStatus(promiseId).data?.toReadyStatusModel()
         }.recoverCatching {
-            return it.toApiResult()
+            return it.handleThrowable()
         }
 
     override suspend fun patchReady(promiseId: Int): Result<Unit> = runCatching {
@@ -52,7 +52,7 @@ internal class HomeRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun patchMoving(promiseId: Int): Result<Unit> = runCatching {
@@ -60,7 +60,7 @@ internal class HomeRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun patchCompleted(promiseId: Int): Result<Unit> = runCatching {
@@ -68,7 +68,7 @@ internal class HomeRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 
     override suspend fun getMembersReadyStatus(promiseId: Int): Result<List<HomeMembersStatus.Participant?>> =
@@ -77,7 +77,7 @@ internal class HomeRepositoryImpl @Inject constructor(
         }.mapCatching {
             requireNotNull(it)
         }.recoverCatching {
-            return it.toApiResult()
+            return it.handleThrowable()
         }
 
     override suspend fun patchReadyInfoInput(
@@ -93,7 +93,7 @@ internal class HomeRepositoryImpl @Inject constructor(
         }.mapCatching {
             requireNotNull(it)
         }.recoverCatching {
-            return it.toApiResult()
+            return it.handleThrowable()
         }
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -48,25 +48,22 @@ internal class HomeRepositoryImpl @Inject constructor(
         }
 
     override suspend fun patchReady(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchReady(promiseId).data
-    }.mapCatching {
-        requireNotNull(it)
+        homeService.patchReady(promiseId)
+        Unit
     }.recoverCatching {
         return it.handleThrowable()
     }
 
     override suspend fun patchMoving(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchMoving(promiseId).data
-    }.mapCatching {
-        requireNotNull(it)
+        homeService.patchMoving(promiseId)
+        Unit
     }.recoverCatching {
         return it.handleThrowable()
     }
 
     override suspend fun patchCompleted(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchCompleted(promiseId).data
-    }.mapCatching {
-        requireNotNull(it)
+        homeService.patchCompleted(promiseId)
+        Unit
     }.recoverCatching {
         return it.handleThrowable()
     }
@@ -89,9 +86,8 @@ internal class HomeRepositoryImpl @Inject constructor(
             homeService.patchReadyInfoInput(
                 promiseId,
                 RequestReadyInfoInputDto(preparationTime, travelTime),
-            ).data
-        }.mapCatching {
-            requireNotNull(it)
+            )
+            Unit
         }.recoverCatching {
             return it.handleThrowable()
         }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -48,15 +48,27 @@ internal class HomeRepositoryImpl @Inject constructor(
         }
 
     override suspend fun patchReady(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchReady(promiseId)
+        homeService.patchReady(promiseId).data
+    }.mapCatching {
+        requireNotNull(it)
+    }.recoverCatching {
+        return it.toApiResult()
     }
 
     override suspend fun patchMoving(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchMoving(promiseId)
+        homeService.patchMoving(promiseId).data
+    }.mapCatching {
+        requireNotNull(it)
+    }.recoverCatching {
+        return it.toApiResult()
     }
 
     override suspend fun patchCompleted(promiseId: Int): Result<Unit> = runCatching {
-        homeService.patchCompleted(promiseId)
+        homeService.patchCompleted(promiseId).data
+    }.mapCatching {
+        requireNotNull(it)
+    }.recoverCatching {
+        return it.toApiResult()
     }
 
     override suspend fun getMembersReadyStatus(promiseId: Int): Result<List<HomeMembersStatus.Participant?>> =
@@ -81,7 +93,7 @@ internal class HomeRepositoryImpl @Inject constructor(
         }.mapCatching {
             requireNotNull(it)
         }.recoverCatching {
-            it.toApiResult<Unit>()
+            return it.toApiResult()
         }
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/LoginRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.teamkkumul.core.data.repositoryimpl
 
 import com.teamkkumul.core.data.mapper.toLoginModel
 import com.teamkkumul.core.data.repository.LoginRepository
+import com.teamkkumul.core.data.utils.toApiResult
 import com.teamkkumul.core.network.api.LoginService
 import com.teamkkumul.core.network.dto.request.RequestLoginDto
 import com.teamkkumul.model.login.LoginModel
@@ -14,13 +15,14 @@ internal class LoginRepositoryImpl @Inject constructor(
         socialType: String,
         fcmToken: String,
         header: String,
-    ): Result<LoginModel> =
-        runCatching {
-            loginService.postLogin(
-                RequestLoginDto(socialType, fcmToken),
-                header,
-            ).data?.toLoginModel() ?: throw Exception("null")
-        }.onFailure { throwable ->
-            return Result.failure(Exception(throwable.message))
-        }
+    ): Result<LoginModel> = runCatching {
+        loginService.postLogin(
+            RequestLoginDto(socialType, fcmToken),
+            header,
+        ).data?.toLoginModel()
+    }.mapCatching {
+        requireNotNull(it)
+    }.recoverCatching {
+        return it.toApiResult()
+    }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/LoginRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.teamkkumul.core.data.repositoryimpl
 
 import com.teamkkumul.core.data.mapper.toLoginModel
 import com.teamkkumul.core.data.repository.LoginRepository
-import com.teamkkumul.core.data.utils.toApiResult
+import com.teamkkumul.core.data.utils.handleThrowable
 import com.teamkkumul.core.network.api.LoginService
 import com.teamkkumul.core.network.dto.request.RequestLoginDto
 import com.teamkkumul.model.login.LoginModel
@@ -23,6 +23,6 @@ internal class LoginRepositoryImpl @Inject constructor(
     }.mapCatching {
         requireNotNull(it)
     }.recoverCatching {
-        return it.toApiResult()
+        return it.handleThrowable()
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpCreateLocationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpCreateLocationRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.teamkkumul.core.data.repositoryimpl
 import com.teamkkumul.core.data.mapper.toMeetUpCreateLocationModel
 import com.teamkkumul.core.data.mapper.toRequestMeetUpCreateDto
 import com.teamkkumul.core.data.repository.MeetUpCreateLocationRepository
-import com.teamkkumul.core.data.utils.toApiResult
+import com.teamkkumul.core.data.utils.handleThrowable
 import com.teamkkumul.core.network.api.MeetUpCreateService
 import com.teamkkumul.model.MeetUpCreateLocationModel
 import com.teamkkumul.model.MeetUpCreateModel
@@ -32,7 +32,7 @@ class MeetUpCreateLocationRepositoryImpl @Inject constructor(
         }.mapCatching {
             requireNotNull(it)
         }.recoverCatching {
-            return it.toApiResult()
+            return it.handleThrowable()
         }
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpCreateLocationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpCreateLocationRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.teamkkumul.core.data.repositoryimpl
 import com.teamkkumul.core.data.mapper.toMeetUpCreateLocationModel
 import com.teamkkumul.core.data.mapper.toRequestMeetUpCreateDto
 import com.teamkkumul.core.data.repository.MeetUpCreateLocationRepository
+import com.teamkkumul.core.data.utils.toApiResult
 import com.teamkkumul.core.network.api.MeetUpCreateService
 import com.teamkkumul.model.MeetUpCreateLocationModel
 import com.teamkkumul.model.MeetUpCreateModel
@@ -27,7 +28,11 @@ class MeetUpCreateLocationRepositoryImpl @Inject constructor(
             meetUpCreateLocationService.postNewMeetUp(
                 meetingId,
                 requestDto,
-            ).data?.promiseId ?: throw Exception("null")
+            ).data?.promiseId
+        }.mapCatching {
+            requireNotNull(it)
+        }.recoverCatching {
+            return it.toApiResult()
         }
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/utils/getErrorMessage.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/utils/getErrorMessage.kt
@@ -6,7 +6,7 @@ import com.teamkkumul.model.network.NetWorkConnectError
 import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 import retrofit2.Response
-import java.io.IOException
+import java.net.UnknownHostException
 
 private const val UNKNOWN_ERROR_MESSAGE = "Unknown error"
 
@@ -27,7 +27,7 @@ private fun parseErrorMessage(errorBody: String): String {
 fun <T> Throwable.toApiResult(): Result<T> {
     return when (this) {
         is HttpException -> Result.failure(ApiError(this.getErrorMessage()))
-        is IOException -> Result.failure(NetWorkConnectError("인터넷에 연결해 주세요"))
+        is UnknownHostException -> Result.failure(NetWorkConnectError("인터넷에 연결해 주세요"))
         else -> Result.failure(this)
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/utils/getErrorMessage.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/utils/getErrorMessage.kt
@@ -24,12 +24,14 @@ private fun parseErrorMessage(errorBody: String): String {
     }
 }
 
-fun <T> Throwable.toApiResult(): Result<T> {
-    return when (this) {
-        is HttpException -> Result.failure(ApiError(this.getErrorMessage()))
-        is UnknownHostException -> Result.failure(NetWorkConnectError("인터넷에 연결해 주세요"))
-        else -> Result.failure(this)
-    }
+fun <T> Throwable.handleThrowable(): Result<T> {
+    return Result.failure(
+        when (this) {
+            is HttpException -> ApiError(this.getErrorMessage())
+            is UnknownHostException -> NetWorkConnectError("인터넷에 연결해 주세요")
+            else -> this
+        },
+    )
 }
 
 fun Response<*>?.getResponseErrorMessage(): String {

--- a/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
@@ -10,6 +10,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.teamkkumul.core.ui.base.BindingFragment
 import com.teamkkumul.core.ui.util.context.colorOf
+import com.teamkkumul.core.ui.util.fragment.toast
 import com.teamkkumul.core.ui.util.fragment.viewLifeCycle
 import com.teamkkumul.core.ui.util.fragment.viewLifeCycleScope
 import com.teamkkumul.core.ui.view.UiState
@@ -74,8 +75,8 @@ class MeetUpLevelFragment :
                     )
                 }
 
-                is UiState.Failure -> Timber.tag("meetupcreate").d(it.errorMessage)
-                else -> {}
+                is UiState.Failure -> toast(it.errorMessage)
+                else -> Unit
             }
         }.launchIn(viewLifeCycleScope)
     }

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
@@ -27,12 +27,12 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     override fun initView() {
         viewModel.getMyPageUserInfo()
         initObserveMyPageState()
-        initGetName()
+        initUserName()
         setSpanText()
     }
 
-    private fun initGetName() {
-        viewModel.getName()
+    private fun initUserName() {
+        viewModel.getLocalUserName()
         viewModel.userName.flowWithLifecycle(viewLifeCycle).onEach {
             binding.tvMyPageName.text = it
         }.launchIn(viewLifeCycleScope)

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
@@ -17,6 +17,7 @@ import com.teamkkumul.feature.utils.setEmptyImageUrl
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -27,15 +28,14 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     override fun initView() {
         viewModel.getMyPageUserInfo()
         initObserveMyPageState()
-        initGetName()
+        initUserName()
         setSpanText()
     }
 
-    private fun initGetName() {
-        viewModel.getName()
-        viewModel.userName.flowWithLifecycle(viewLifeCycle).onEach {
-            binding.tvMyPageName.text = it
-        }.launchIn(viewLifeCycleScope)
+    private fun initUserName() {
+        viewLifeCycleScope.launch {
+            binding.tvMyPageName.text = viewModel.getUserName()
+        }
     }
 
     private fun initObserveMyPageState() {

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageFragment.kt
@@ -17,7 +17,6 @@ import com.teamkkumul.feature.utils.setEmptyImageUrl
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -28,14 +27,15 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     override fun initView() {
         viewModel.getMyPageUserInfo()
         initObserveMyPageState()
-        initUserName()
+        initGetName()
         setSpanText()
     }
 
-    private fun initUserName() {
-        viewLifeCycleScope.launch {
-            binding.tvMyPageName.text = viewModel.getUserName()
-        }
+    private fun initGetName() {
+        viewModel.getName()
+        viewModel.userName.flowWithLifecycle(viewLifeCycle).onEach {
+            binding.tvMyPageName.text = it
+        }.launchIn(viewLifeCycleScope)
     }
 
     private fun initObserveMyPageState() {

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
@@ -10,7 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,8 +22,6 @@ class MyPageViewModel @Inject constructor(
     private val _myPageState = MutableStateFlow<UiState<UserModel>>(UiState.Loading)
     val myPageState: StateFlow<UiState<UserModel>> = _myPageState.asStateFlow()
 
-    private val _userName = MutableStateFlow<String>("")
-    val userName: StateFlow<String> = _userName.asStateFlow()
     fun getMyPageUserInfo() {
         viewModelScope.launch {
             homeRepository.getUserInfo()
@@ -39,11 +37,5 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun getName() {
-        viewModelScope.launch {
-            userInfoRepository.getMemberName().collectLatest {
-                _userName.value = it
-            }
-        }
-    }
+    suspend fun getUserName(): String = userInfoRepository.getMemberName().first()
 }

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
@@ -39,7 +39,7 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun getName() {
+    fun getLocalUserName() {
         viewModelScope.launch {
             userInfoRepository.getMemberName().collectLatest {
                 _userName.value = it

--- a/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mypage/MyPageViewModel.kt
@@ -10,7 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,6 +22,8 @@ class MyPageViewModel @Inject constructor(
     private val _myPageState = MutableStateFlow<UiState<UserModel>>(UiState.Loading)
     val myPageState: StateFlow<UiState<UserModel>> = _myPageState.asStateFlow()
 
+    private val _userName = MutableStateFlow<String>("")
+    val userName: StateFlow<String> = _userName.asStateFlow()
     fun getMyPageUserInfo() {
         viewModelScope.launch {
             homeRepository.getUserInfo()
@@ -37,5 +39,11 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    suspend fun getUserName(): String = userInfoRepository.getMemberName().first()
+    fun getName() {
+        viewModelScope.launch {
+            userInfoRepository.getMemberName().collectLatest {
+                _userName.value = it
+            }
+        }
+    }
 }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #108 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] error handling 로직 수정
- [x] reissue 에러 수정

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
**에러 핸들링 방안**

1. Result<Model>을 retrun하는 경우 (함수의 리턴 타입에 null 허용  하지 않은 경우)
```kotlin
    override suspend fun getUpComingMeeting(): Result<List<HomeTodayMeetingModel>> = runCatching {
        homeService.getUpComingMeeting().data?.promises?.map { it.toPromiseModel() }
    }.mapCatching {
        requireNotNull(it)
    }.recoverCatching {
        return it.handleThrowable()
    }
```
mapCatching을 통해 requireNotNull(it)가 null을 검출할 때 기본 메시지인 "Required value was null."를 포함하는 IllegalArgumentException을 던집니다.
따라서, 최종적으로 전달되는 메시지는 "Required value was null."이 됩니다

recoverCatching 을 통해 thrwoable의 확장함수인 handleThrowable()을 통해 서버로부터의 error message를 파싱합니다. 만약 네트워크 연결이 안된경우 UnknownHostException을 통해 "네트워크 연결 없음" 을 전달합니다.

2. Result<Mode?>을 retrun하는 경우 (함수의 리턴 타입에 null 허용 한 경우)
```kotlin
    override suspend fun getReadyStatus(promiseId: Int): Result<HomeReadyStatusModel?> =
        runCatching {
            homeService.getReadyStatus(promiseId).data?.toReadyStatusModel()
        }.recoverCatching {
            return it.handleThrowable()
        }
```
이 경우 null가능성을 미리 선언 하였으므로 예기치 못한 서버 null exception오류에 대해 대응할 필요가 없습니다.
따라서 mapcatching을 통한 null체크는 필요 없고 바로 recoverCatching혹은 onFailure블록을 선언하여 서버 에러를 파싱하면 됩니다.

handleThrowable() 확장 함수는 서버 에러(errorbody)를 파싱하는 함수 입니다. baseResopnse타입에 혼동이 있어서 그간 json파싱이 원할하게 안됬네요...(어이 업슈ㅠㅠ)

각자가 맡은 부분 에러 핸들링 로직을 해당 pr참고하셔서 수정하시면 됩니다!
화면에 나와야 하는 서버에서 제공한 에러 -> toast메세지
화면에 나올 필요 없는 서버에서 제공한 에러 -> timber로 로깅하시면 됩니다.

사실 post나 patch제외하고는 해당 에러 핸들링은 매번 할 필요 없긴 합니다만 효율적인 코딩을 위해 사용해보는 것도 좋을 것 같습니다!