### PR TITLE
[Feat/#111] group list error handling

### DIFF
--- a/core/data/src/main/java/com/teamkkumul/core/data/repository/MyGroupRepository.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repository/MyGroupRepository.kt
@@ -7,7 +7,7 @@ import com.teamkkumul.model.MyGroupMemberModel
 import com.teamkkumul.model.MyGroupModel
 
 interface MyGroupRepository {
-    suspend fun getMyGroup(): Result<MyGroupModel?>
+    suspend fun getMyGroup(): Result<MyGroupModel>
     suspend fun getMyGroupMeetUp(
         meetingId: Int,
         done: Boolean,

--- a/core/data/src/main/java/com/teamkkumul/core/data/repository/MyGroupRepository.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repository/MyGroupRepository.kt
@@ -7,7 +7,7 @@ import com.teamkkumul.model.MyGroupMemberModel
 import com.teamkkumul.model.MyGroupModel
 
 interface MyGroupRepository {
-    suspend fun getMyGroup(): Result<MyGroupModel>
+    suspend fun getMyGroup(): Result<MyGroupModel?>
     suspend fun getMyGroupMeetUp(
         meetingId: Int,
         done: Boolean,

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MyGroupRepositoryImpl.kt
@@ -19,8 +19,10 @@ import javax.inject.Inject
 class MyGroupRepositoryImpl @Inject constructor(
     private val myGroupService: MyGroupService,
 ) : MyGroupRepository {
-    override suspend fun getMyGroup(): Result<MyGroupModel?> = runCatching {
+    override suspend fun getMyGroup(): Result<MyGroupModel> = runCatching {
         myGroupService.getMyGroupList().data?.toMyGroupModel()
+    }.mapCatching { myGroupModel ->
+        requireNotNull(myGroupModel)
     }.recoverCatching {
         return it.handleThrowable()
     }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MyGroupRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MyGroupRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.teamkkumul.core.data.mapper.toMyGroupMemberToMeetUp
 import com.teamkkumul.core.data.mapper.toMyGroupModel
 import com.teamkkumul.core.data.mapper.toMyGroupSealedItem
 import com.teamkkumul.core.data.repository.MyGroupRepository
+import com.teamkkumul.core.data.utils.handleThrowable
 import com.teamkkumul.core.network.api.MyGroupService
 import com.teamkkumul.model.MyGroupDetailMemeberSealedItem
 import com.teamkkumul.model.MyGroupInfoModel
@@ -18,9 +19,10 @@ import javax.inject.Inject
 class MyGroupRepositoryImpl @Inject constructor(
     private val myGroupService: MyGroupService,
 ) : MyGroupRepository {
-    override suspend fun getMyGroup(): Result<MyGroupModel> = runCatching {
-        val response = myGroupService.getMyGroupList()
-        response.data?.toMyGroupModel() ?: throw Exception("null")
+    override suspend fun getMyGroup(): Result<MyGroupModel?> = runCatching {
+        myGroupService.getMyGroupList().data?.toMyGroupModel()
+    }.recoverCatching {
+        return it.handleThrowable()
     }
 
     override suspend fun getMyGroupMeetUp(

--- a/feature/src/main/java/com/teamkkumul/feature/mygroup/MyGroupViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mygroup/MyGroupViewModel.kt
@@ -41,12 +41,11 @@ class MyGroupViewModel @Inject constructor(
     fun getMyGroupList() = viewModelScope.launch {
         myGroupRepository.getMyGroup()
             .onSuccess { myGroupModel ->
-                if (myGroupModel.meetings.isEmpty()) {
+                if (myGroupModel == null) {
                     _myGroupListState.emit(UiState.Empty)
                 } else {
                     _myGroupListState.emit(UiState.Success(myGroupModel.meetings))
                 }
-                _myGroupState.emit(UiState.Success(myGroupModel))
             }
             .onFailure { exception ->
                 _myGroupState.emit(UiState.Failure(exception.message.toString()))

--- a/feature/src/main/java/com/teamkkumul/feature/mygroup/MyGroupViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mygroup/MyGroupViewModel.kt
@@ -41,7 +41,7 @@ class MyGroupViewModel @Inject constructor(
     fun getMyGroupList() = viewModelScope.launch {
         myGroupRepository.getMyGroup()
             .onSuccess { myGroupModel ->
-                if (myGroupModel == null) {
+                if (myGroupModel.meetings.isEmpty()) {
                     _myGroupListState.emit(UiState.Empty)
                 } else {
                     _myGroupListState.emit(UiState.Success(myGroupModel.meetings))


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #111 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 내 모임 리스트 화면 error handling

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
![image](https://github.com/user-attachments/assets/a62b1d0d-a406-49b3-95a4-9c5a8c744817)


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
이후에 내 모임 상세 화면, 약속 상세 화면, 약속 추가 화면 따로 브랜치 파서 작업할 예정입니다.
이번 pr에서 많이 바꾼 부분은 없으나, empty view를 가진 fragment에서의 get 통신시 error handling 하는 법을 처음으로 적용해보았습니다. 확인 부탁드립니다. 감사합니다!
