### PR TITLE
[FIX/#119] 약속 마치기 기능 수정

### DIFF
--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpRepositoryImpl.kt
@@ -43,10 +43,10 @@ class MeetUpRepositoryImpl @Inject constructor(
         return it.handleThrowable()
     }
 
-    override suspend fun patchMeetUpComplete(promiseId: Int): Result<Unit> {
-        return runCatching {
-            val response = meetUpService.patchMeetUpComplete(promiseId)
-            response.data ?: throw Exception("null")
-        }
+    override suspend fun patchMeetUpComplete(promiseId: Int): Result<Unit> = runCatching {
+        meetUpService.patchMeetUpComplete(promiseId)
+        Unit
+    }.recoverCatching {
+        return it.handleThrowable()
     }
 }

--- a/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpRepositoryImpl.kt
+++ b/core/data/src/main/java/com/teamkkumul/core/data/repositoryimpl/MeetUpRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.teamkkumul.core.data.mapper.toMeetUpDetailModel
 import com.teamkkumul.core.data.mapper.toMeetUpParticipantModel
 import com.teamkkumul.core.data.mapper.toMeetUpSealedItem
 import com.teamkkumul.core.data.repository.MeetUpRepository
+import com.teamkkumul.core.data.utils.handleThrowable
 import com.teamkkumul.core.network.api.MeetUpService
 import com.teamkkumul.model.LatePersonModel
 import com.teamkkumul.model.MeetUpDetailModel
@@ -34,12 +35,12 @@ class MeetUpRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getLateComersList(promiseId: Int): Result<LatePersonModel> {
-        return runCatching {
-            meetUpService.getLateComersList(promiseId).data?.toLatePersonModel() ?: throw Exception(
-                "null",
-            )
-        }
+    override suspend fun getLateComersList(promiseId: Int): Result<LatePersonModel> = runCatching {
+        meetUpService.getLateComersList(promiseId).data?.toLatePersonModel()
+    }.mapCatching { latePersonModel ->
+        requireNotNull(latePersonModel)
+    }.recoverCatching {
+        return it.handleThrowable()
     }
 
     override suspend fun patchMeetUpComplete(promiseId: Int): Result<Unit> {

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -116,11 +116,7 @@ class LatePersonFragment :
                     }
 
                     is UiState.Failure -> {
-                        if (latePersonViewModel.isPastDue) {
-                            toast("도착하지 않은 참여자가 있습니다.")
-                        } else {
-                            toast("약속 시간이 지나지 않았습니다.")
-                        }
+                        toast(patchMeetUpState.errorMessage)
                     }
 
                     else -> Unit

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.teamkkumul.core.ui.base.BindingFragment
 import com.teamkkumul.core.ui.util.context.pxToDp
@@ -104,7 +105,10 @@ class LatePersonFragment :
             .onEach { patchMeetUpState ->
                 when (patchMeetUpState) {
                     is UiState.Success -> {
-                        toast("약속 마치기 성공 !")
+                        if (latePersonViewModel.isPastDue) {
+                            toast("약속 마치기 성공 !")
+                            findNavController().popBackStack()
+                        }
                     }
 
                     is UiState.Failure -> {

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -54,7 +54,10 @@ class LatePersonFragment :
             .onEach { latePersonState ->
                 when (latePersonState) {
                     is UiState.Success -> handleSuccessState(latePersonState.data)
-                    is UiState.Failure -> showFailureState()
+                    is UiState.Failure -> {
+                        showFailureState()
+                        updateButtonState(false)
+                    }
                     else -> Unit
                 }
             }.launchIn(viewLifeCycleScope)
@@ -62,6 +65,7 @@ class LatePersonFragment :
 
     private fun handleSuccessState(data: LatePersonModel) {
         initPenaltyState(data)
+        updateButtonState(data.isPastDue)
         if (!data.isPastDue) {
             showFailureState()
             return
@@ -124,6 +128,10 @@ class LatePersonFragment :
         binding.btnEndMeetUp.setOnClickListener {
             latePersonViewModel.patchMeetUpComplete(promiseId)
         }
+    }
+
+    private fun updateButtonState(isPastDue: Boolean) {
+        binding.btnEndMeetUp.isEnabled = isPastDue
     }
 
     companion object {

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -59,6 +59,7 @@ class LatePersonFragment :
                         showFailureState()
                         updateButtonState(false)
                     }
+
                     else -> Unit
                 }
             }.launchIn(viewLifeCycleScope)
@@ -91,6 +92,11 @@ class LatePersonFragment :
     private fun showEmptyState() {
         updateViewVisibility(binding.rvLatePerson, false)
         updateViewVisibility(binding.viewLatePersonEmpty, true)
+        updateViewVisibility(binding.ivBoxPenalty, false)
+        updateViewVisibility(binding.ivPenaltyIcon, false)
+        updateViewVisibility(binding.tvPenalty, false)
+        updateViewVisibility(binding.tvPenaltyDescription, false)
+        updateViewVisibility(binding.tvLatePersonQuestion, false)
     }
 
     private fun showLateComers(lateComers: List<LatePersonModel.LateComers>) {
@@ -105,10 +111,8 @@ class LatePersonFragment :
             .onEach { patchMeetUpState ->
                 when (patchMeetUpState) {
                     is UiState.Success -> {
-                        if (latePersonViewModel.isPastDue) {
-                            toast("약속 마치기 성공 !")
-                            findNavController().popBackStack()
-                        }
+                        toast("약속 마치기 성공 !")
+                        findNavController().popBackStack()
                     }
 
                     is UiState.Failure -> {

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -61,12 +61,11 @@ class LatePersonFragment :
     }
 
     private fun handleSuccessState(data: LatePersonModel) {
+        initPenaltyState(data)
         if (!data.isPastDue) {
             showFailureState()
             return
         }
-
-        initPenaltyState(data)
         if (data.lateComers.isEmpty()) {
             showEmptyState()
         } else {
@@ -105,7 +104,7 @@ class LatePersonFragment :
                     }
 
                     is UiState.Failure -> {
-                        toast("약속 시간이 아직 안됬어요")
+                        toast("도착하지 않은 참여자가 있습니다.")
                     }
 
                     else -> Unit

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonFragment.kt
@@ -104,7 +104,11 @@ class LatePersonFragment :
                     }
 
                     is UiState.Failure -> {
-                        toast("도착하지 않은 참여자가 있습니다.")
+                        if (latePersonViewModel.isPastDue) {
+                            toast("도착하지 않은 참여자가 있습니다.")
+                        } else {
+                            toast("약속 시간이 지나지 않았습니다.")
+                        }
                     }
 
                     else -> Unit

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonViewModel.kt
@@ -19,9 +19,6 @@ class LatePersonViewModel @Inject constructor(
     private val _latePersonState = MutableStateFlow<UiState<LatePersonModel>>(UiState.Loading)
     val latePersonState get() = _latePersonState.asStateFlow()
 
-    private var _isPastDue: Boolean = false
-    val isPastDue: Boolean get() = _isPastDue
-
     private val _patchMeetUpState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
     val patchMeetUpState get() = _patchMeetUpState.asStateFlow()
 
@@ -30,7 +27,6 @@ class LatePersonViewModel @Inject constructor(
             meetUpRepository.getLateComersList(promiseId)
                 .onSuccess {
                     _latePersonState.emit(UiState.Success(it))
-                    _isPastDue = it.isPastDue
                 }.onFailure { exception ->
                     _latePersonState.emit(UiState.Failure(exception.message.toString()))
                 }

--- a/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetup/lateperson/LatePersonViewModel.kt
@@ -19,6 +19,9 @@ class LatePersonViewModel @Inject constructor(
     private val _latePersonState = MutableStateFlow<UiState<LatePersonModel>>(UiState.Loading)
     val latePersonState get() = _latePersonState.asStateFlow()
 
+    private var _isPastDue: Boolean = false
+    val isPastDue: Boolean get() = _isPastDue
+
     private val _patchMeetUpState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
     val patchMeetUpState get() = _patchMeetUpState.asStateFlow()
 
@@ -27,6 +30,7 @@ class LatePersonViewModel @Inject constructor(
             meetUpRepository.getLateComersList(promiseId)
                 .onSuccess {
                     _latePersonState.emit(UiState.Success(it))
+                    _isPastDue = it.isPastDue
                 }.onFailure { exception ->
                     _latePersonState.emit(UiState.Failure(exception.message.toString()))
                 }

--- a/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
@@ -109,15 +109,6 @@ class MeetUpLevelFragment :
         button.setOnClickListener {
             val selectedMeetUpLevel = getSelectedChipText(binding.cgMeetUpLevel)
             val selectedPenalty = getSelectedChipText(binding.cgSetPenalty)
-
-            Timber.d("Selected Meet Up Level~: $selectedMeetUpLevel")
-            Timber.d("Selected Penalty~: $selectedPenalty")
-
-            val bundle = arguments?.apply {
-                putString(KeyStorage.MEET_UP_LEVEL, selectedMeetUpLevel)
-                putString(KeyStorage.PENALTY, selectedPenalty)
-            }
-
             val dressUpLevel = preprocessDressUpLevel(selectedMeetUpLevel)
 
             val meetUpCreateModel = MeetUpCreateModel(
@@ -138,18 +129,13 @@ class MeetUpLevelFragment :
     }
 
     private fun preprocessDressUpLevel(dressUpLevel: String): String {
-        // Define a regular expression pattern to match "LV" followed by digits
         val pattern = Regex("LV\\s*(\\d+)")
-
-        // Find the first match in the input string
         val matchResult = pattern.find(dressUpLevel)
 
         return if (matchResult != null) {
-            // Extract the digit part and concatenate with "LV"
             "LV${matchResult.groupValues[1]}"
         } else {
-            // Return a default value or an empty string if no match is found
-            "LV1" // or return "" if you prefer
+            "FREE"
         }
     }
 

--- a/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/meetupcreate/meetuplevel/MeetUpLevelFragment.kt
@@ -129,8 +129,7 @@ class MeetUpLevelFragment :
     }
 
     private fun preprocessDressUpLevel(dressUpLevel: String): String {
-        val pattern = Regex("LV\\s*(\\d+)")
-        val matchResult = pattern.find(dressUpLevel)
+        val matchResult = DRESS_UP_LEVEL_PATTERN.find(dressUpLevel)
 
         return if (matchResult != null) {
             "LV${matchResult.groupValues[1]}"
@@ -178,5 +177,9 @@ class MeetUpLevelFragment :
             }
         }
         return ""
+    }
+
+    companion object {
+        private val DRESS_UP_LEVEL_PATTERN = Regex("LV\\s*(\\d+)")
     }
 }

--- a/feature/src/main/res/layout/fragment_late_person.xml
+++ b/feature/src/main/res/layout/fragment_late_person.xml
@@ -12,6 +12,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <include
+            android:id="@+id/view_late_person_empty"
+            layout="@layout/view_late_person_empty"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <ImageView
             android:id="@+id/iv_box_penalty"
             android:layout_width="match_parent"
@@ -99,15 +108,6 @@
             app:layout_constraintDimensionRatio="332:50"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
-
-        <include
-            android:id="@+id/view_late_person_empty"
-            layout="@layout/view_late_person_empty"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <include
             android:id="@+id/view_waiting_empty"

--- a/feature/src/main/res/layout/view_late_person_empty.xml
+++ b/feature/src/main/res/layout/view_late_person_empty.xml
@@ -38,20 +38,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_congratulations" />
 
-<!--    <Button-->
-<!--        android:id="@+id/btn_end_meet_up"-->
-<!--        android:layout_width="0dp"-->
-<!--        android:layout_height="0dp"-->
-<!--        android:layout_marginHorizontal="14dp"-->
-<!--        android:layout_marginBottom="50dp"-->
-<!--        android:background="@drawable/shape_gray_fill_8_rect"-->
-<!--        android:backgroundTint="@color/main_color"-->
-<!--        android:text="@string/end_meet_up"-->
-<!--        android:textAppearance="@style/TextAppearance.Kkumul.body_03"-->
-<!--        app:layout_constraintBottom_toBottomOf="parent"-->
-<!--        app:layout_constraintDimensionRatio="332:50"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        app:layout_constraintStart_toStartOf="parent" />-->
-
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/src/main/res/layout/view_late_person_empty.xml
+++ b/feature/src/main/res/layout/view_late_person_empty.xml
@@ -38,20 +38,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_congratulations" />
 
-    <Button
-        android:id="@+id/btn_end_meet_up"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginHorizontal="14dp"
-        android:layout_marginBottom="50dp"
-        android:background="@drawable/shape_gray_fill_8_rect"
-        android:backgroundTint="@color/main_color"
-        android:text="@string/end_meet_up"
-        android:textAppearance="@style/TextAppearance.Kkumul.body_03"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintDimensionRatio="332:50"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+<!--    <Button-->
+<!--        android:id="@+id/btn_end_meet_up"-->
+<!--        android:layout_width="0dp"-->
+<!--        android:layout_height="0dp"-->
+<!--        android:layout_marginHorizontal="14dp"-->
+<!--        android:layout_marginBottom="50dp"-->
+<!--        android:background="@drawable/shape_gray_fill_8_rect"-->
+<!--        android:backgroundTint="@color/main_color"-->
+<!--        android:text="@string/end_meet_up"-->
+<!--        android:textAppearance="@style/TextAppearance.Kkumul.body_03"-->
+<!--        app:layout_constraintBottom_toBottomOf="parent"-->
+<!--        app:layout_constraintDimensionRatio="332:50"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toStartOf="parent" />-->
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #119

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] 약속 마치기 버튼 클릭 시, 시간에 따라 클릭 여부 수정
- [x] toast 메시지 처리
- [x] 지각 꾸물이 화면 분기처리 확인 - 벌칙 잘 뜨는지 확인
- [x] 에러 핸들링
- [x] 약속 생성 시, '마음대로 입고 오기' 오류 해결
- [x] 약속 마치기 후 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/user-attachments/assets/dbe13393-8da2-48ed-97a4-8e94a037b36c


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
약속 마치기 (지각 꾸물이) 화면에서 상황에 따른 분기처리와 에러 핸들링을 진행하였고, 
약속 추가하기의 꾸레벨, 벌칙 설정 화면에서 꾸레벨을 dto에 알맞게 전달하는 작업 진행하였습니다. 

+) 지각 꾸물이 화면 중 도착 시간 이후 지각자가 없는 경우의 화면에서 (viewLatePersonEmpty), 
다른 화면 경우의 수들은 배경색이 흰색인데 이 경우만 green1이어서, 
버튼은 항상 있는 공통 view로 가져가기 위해, 
viewLatePersonEmpty를 화면 가장 뒤쪽 view로 보내고, 겹쳐서 나타나는 LatePersonFragment의 view들을 isVisible false 처리하였습니다. 
기능은 잘 적용이 되긴 하는데, 혹시 조금 더 좋은 방법이 있다면 알려주시면 감사하겠습니다 !