### PR TITLE
#189 [feat] : 내 모임의 약속 d-day 기준으로 정렬 usecase 구현

### DIFF
--- a/core/domain/src/main/java/com/chanu/core/domain/usecase/GetMyGroupMeetUpUseCase.kt
+++ b/core/domain/src/main/java/com/chanu/core/domain/usecase/GetMyGroupMeetUpUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetMyGroupMeetUpUseCase @Inject constructor(
     private val myGroupRepository: MyGroupRepository,
 ) {
-    suspend fun invoke(
+    suspend operator fun invoke(
         meetingId: Int,
         done: Boolean,
         isParticipant: Boolean? = null,

--- a/core/domain/src/main/java/com/chanu/core/domain/usecase/GetMyGroupMeetUpUseCase.kt
+++ b/core/domain/src/main/java/com/chanu/core/domain/usecase/GetMyGroupMeetUpUseCase.kt
@@ -1,0 +1,28 @@
+package com.chanu.core.domain.usecase
+
+import com.teamkkumul.core.data.repository.MyGroupRepository
+import com.teamkkumul.model.MyGroupMeetUpModel
+import javax.inject.Inject
+
+class GetMyGroupMeetUpUseCase @Inject constructor(
+    private val myGroupRepository: MyGroupRepository,
+) {
+    suspend fun invoke(
+        meetingId: Int,
+        done: Boolean,
+        isParticipant: Boolean? = null,
+    ): Result<List<MyGroupMeetUpModel.Promise>> =
+        myGroupRepository.getMyGroupMeetUp(meetingId, done, isParticipant)
+            .mapCatching { promises ->
+                promises.sortedWith(
+                    compareBy<MyGroupMeetUpModel.Promise> {
+                        when {
+                            it.dDay == 0 -> -1
+                            it.dDay < 0 -> 0
+                            else -> 1
+                        }
+                    }.thenByDescending { it.dDay.takeIf { d -> d < 0 } } // 음수는 내림차순 정렬
+                        .thenBy { it.dDay.takeIf { d -> d > 0 } }, // 양수는 오름차순 정렬
+                )
+            }
+}

--- a/feature/src/main/java/com/teamkkumul/feature/mygroup/mygroupdetail/MyGroupDetailViewModel.kt
+++ b/feature/src/main/java/com/teamkkumul/feature/mygroup/mygroupdetail/MyGroupDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.teamkkumul.feature.mygroup.mygroupdetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chanu.core.domain.usecase.GetMyGroupMeetUpUseCase
 import com.teamkkumul.core.data.repository.MyGroupRepository
 import com.teamkkumul.core.ui.view.UiState
 import com.teamkkumul.model.MyGroupDetailMemeberSealedItem
@@ -17,8 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyGroupDetailViewModel @Inject constructor(
     private val myGroupRepository: MyGroupRepository,
+    private val getMyGroupMeetUpUseCase: GetMyGroupMeetUpUseCase,
 ) : ViewModel() {
-
     private val _myGroupInfoState = MutableStateFlow<UiState<MyGroupInfoModel>>(UiState.Loading)
     val myGroupInfoState get() = _myGroupInfoState.asStateFlow()
 
@@ -64,7 +65,7 @@ class MyGroupDetailViewModel @Inject constructor(
 
     fun getMyGroupMeetUp(meetingId: Int, done: Boolean, isParticipant: Boolean? = null) =
         viewModelScope.launch {
-            myGroupRepository.getMyGroupMeetUp(meetingId, done, isParticipant)
+            getMyGroupMeetUpUseCase.invoke(meetingId, done, isParticipant)
                 .onSuccess { myGroupMemberModel ->
                     if (myGroupMemberModel.isEmpty()) {
                         _myGroupMeetUpState.emit(UiState.Empty)


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #189 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- [x] '내 모임 상세'의 '남은 약속을 확인해보세요'에서 약속 노출의 순서를
D-DAY -> D-N (D-1 -> D-2) -> D+N (D+1 -> D+2) 순으로 usecase  sort 적용

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/user-attachments/assets/9eb5d087-ebee-4c14-8050-270803d7ec0e



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
usecase는 domain모듈에 존재하며
단일 책임 원칙에 따라, 뷰모델 class에 지나친 책임이 있을 때 각 비즈니스 로직을 분리할때 좋습니다!!